### PR TITLE
Add listing and loading functionality to EmlReader

### DIFF
--- a/eml_reader.py
+++ b/eml_reader.py
@@ -1,4 +1,45 @@
+from __future__ import annotations
+
+from pathlib import Path
 
 
 class EmlReader:
-    pass
+    """Utility class for working with ``.eml`` files stored in a directory."""
+
+    def __init__(self, directory: Path | str) -> None:
+        self._directory = Path(directory)
+        if not self._directory.exists():
+            raise FileNotFoundError(f"Directory '{self._directory}' does not exist")
+        if not self._directory.is_dir():
+            raise NotADirectoryError(f"'{self._directory}' is not a directory")
+
+    @property
+    def directory(self) -> Path:
+        """Return the directory containing the ``.eml`` files."""
+
+        return self._directory
+
+    def list_emls(self) -> list[Path]:
+        """Return a sorted list of ``.eml`` files from the directory."""
+
+        eml_files = [
+            path
+            for path in self._directory.iterdir()
+            if path.is_file() and path.suffix.lower() == ".eml"
+        ]
+        return sorted(eml_files)
+
+    def load_eml_by_index(self, index: int) -> bytes:
+        """Load the content of an ``.eml`` file selected by its index."""
+
+        eml_files = self.list_emls()
+        try:
+            selected = eml_files[index]
+        except IndexError as exc:
+            raise IndexError(
+                f"Index {index} is out of range for {len(eml_files)} available .eml files"
+            ) from exc
+        return selected.read_bytes()
+
+
+__all__ = ["EmlReader"]

--- a/tests/test_eml_reader.py
+++ b/tests/test_eml_reader.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from eml_reader import EmlReader
+
+
+def create_eml(directory: Path, name: str, content: str) -> Path:
+    path = directory / name
+    path.write_text(content)
+    return path
+
+
+def test_list_emls_returns_sorted_eml_files(tmp_path: Path) -> None:
+    eml_dir = tmp_path / "emls"
+    eml_dir.mkdir()
+    create_eml(eml_dir, "b.eml", "second")
+    create_eml(eml_dir, "a.eml", "first")
+    (eml_dir / "note.txt").write_text("ignore")
+
+    reader = EmlReader(eml_dir)
+
+    eml_files = reader.list_emls()
+
+    assert [path.name for path in eml_files] == ["a.eml", "b.eml"]
+
+
+def test_load_eml_by_index_returns_bytes(tmp_path: Path) -> None:
+    eml_dir = tmp_path / "emls"
+    eml_dir.mkdir()
+    create_eml(eml_dir, "first.eml", "content one")
+    create_eml(eml_dir, "second.eml", "content two")
+
+    reader = EmlReader(eml_dir)
+
+    content = reader.load_eml_by_index(1)
+
+    assert content == "content two".encode()
+
+
+def test_load_eml_by_index_invalid_index(tmp_path: Path) -> None:
+    eml_dir = tmp_path / "emls"
+    eml_dir.mkdir()
+    create_eml(eml_dir, "only.eml", "content")
+
+    reader = EmlReader(eml_dir)
+
+    with pytest.raises(IndexError):
+        reader.load_eml_by_index(5)


### PR DESCRIPTION
## Summary
- implement the EmlReader class with directory validation and ``.eml`` listing support
- add the ability to load an ``.eml`` file by its index in the listing
- cover the new behaviour with pytest tests for happy path and error scenarios

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cffa45ae3883239be8c18959952a82